### PR TITLE
Only override startsWith and endWith if those are not present

### DIFF
--- a/src/plone/patternslib/static/components/patternslib/src/core/jquery-ext.js
+++ b/src/plone/patternslib/static/components/patternslib/src/core/jquery-ext.js
@@ -223,8 +223,16 @@ define(["jquery"], function($) {
     // XXX: In compat.js we include things for browser compatibility,
     // but these two seem to be only convenience. Do we really want to
     // include these as part of patterns?
-    String.prototype.startsWith = function(str) { return (this.match("^"+str) !== null); };
-    String.prototype.endsWith = function(str) { return (this.match(str+"$") !== null); };
+    if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function (str) {
+            return (this.match("^" + str) !== null);
+        };
+    }
+    if (!String.prototype.endsWith) {
+        String.prototype.endsWith = function(str) {
+            return (this.match(str+"$") !== null);
+        };
+    }
 
 
     /******************************


### PR DESCRIPTION
The `startsWith` and `endWith` methods are overridden/prototyped by default in `jquery-ext.js`. When these methods are already available in the browser these methods should not be overridden.

Maybe the protoTypes should be removed altogether? Most (if not all) modern browsers now support these methods. It also seems the implementation is not correct. For example `startsWith` can also accept a 2th argument for position (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith).

I stumbled upon these methods when a custom javascript app refused to run, because of these prototyped methods. When I disabled the override, the app ran just fine.

<img width="912" alt="screen shot 2018-03-27 at 15 12 38" src="https://user-images.githubusercontent.com/201650/37970501-edb48246-31d3-11e8-8747-574f8124e7be.png">

