### PR TITLE
register pat-datetime-picker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Register ``pat-datetime-picker`` in the resource registry.
+  [thet]
+
 - Restructure upgrades to follow bobtemplates.plone recommendations.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Restructure upgrades to follow bobtemplates.plone recommendations.
+  [thet]
 
 
 1.1.1 (2020-07-10)

--- a/src/plone/patternslib/configure.zcml
+++ b/src/plone/patternslib/configure.zcml
@@ -8,6 +8,7 @@
     i18n_domain="plone.patternslib">
 
   <include package=".browser" />
+  <include package=".upgrades" />
 
   <include package="plone.resource" file="meta.zcml"/>
 
@@ -36,38 +37,6 @@
       directory="profiles/uninstall"
       description="Uninstalls the plone.patternslib add-on."
       provides="Products.GenericSetup.interfaces.EXTENSION"
-      />
-  <genericsetup:upgradeStep
-      title="Remove browser layer"
-      description="Remove unneeded browser layer.."
-      source="1000"
-      destination="1001"
-      handler="plone.patternslib.upgrades.upgrade_1000_1001"
-      profile="plone.patternslib:default"
-      />
-  <genericsetup:upgradeStep
-      title="Remove registry init in patterns"
-      description=""
-      source="1002"
-      destination="1003"
-      handler="plone.patternslib.upgrades.import_profile"
-      profile="plone.patternslib:default"
-      />
-  <genericsetup:upgradeStep
-      title="Remove 2nd markercluster CSS"
-      description=""
-      source="1003"
-      destination="1004"
-      handler="plone.patternslib.upgrades.import_profile"
-      profile="plone.patternslib:default"
-      />
-  <genericsetup:upgradeStep
-      title="Update Bundles"
-      description=""
-      source="1004"
-      destination="1005"
-      handler="plone.patternslib.upgrades.import_profile"
-      profile="plone.patternslib:default"
       />
 
   <utility

--- a/src/plone/patternslib/profiles/default/metadata.xml
+++ b/src/plone/patternslib/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1005</version>
+  <version>1006</version>
 </metadata>

--- a/src/plone/patternslib/profiles/default/registry.xml
+++ b/src/plone/patternslib/profiles/default/registry.xml
@@ -448,6 +448,14 @@
         <value key="url">++plone++patternslib/components/patternslib/src/pat/date-picker</value>
     </records>
 
+    <records prefix="plone.resources/pat-datetime-picker"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+        <value key="js">++plone++patternslib/components/patternslib/src/pat/datetime-picker/datetime-picker.js</value>
+        <value key="css">
+            <element>++plone++patternslib/components/patternslib/src/pat/datetime-picker/datetime-picker.css</element>
+        </value>
+    </records>
+
     <records prefix="plone.resources/pat-depends"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
         <value key="js">++plone++patternslib/components/patternslib/src/pat/depends/depends.js</value>

--- a/src/plone/patternslib/setuphandlers.py
+++ b/src/plone/patternslib/setuphandlers.py
@@ -5,9 +5,12 @@ from zope.interface import implementer
 
 @implementer(INonInstallable)
 class HiddenProfiles(object):
-
     def getNonInstallableProfiles(self):
         """Hide uninstall profile from site-creation and quickinstaller"""
         return [
-            'plone.patternslib:uninstall',
+            "plone.patternslib:uninstall",
+            "plone.patternslib.upgrades:1001",
+            "plone.patternslib.upgrades:1003",
+            "plone.patternslib.upgrades:1004",
+            "plone.patternslib.upgrades:1005",
         ]

--- a/src/plone/patternslib/setuphandlers.py
+++ b/src/plone/patternslib/setuphandlers.py
@@ -13,4 +13,5 @@ class HiddenProfiles(object):
             "plone.patternslib.upgrades:1003",
             "plone.patternslib.upgrades:1004",
             "plone.patternslib.upgrades:1005",
+            "plone.patternslib.upgrades:1006",
         ]

--- a/src/plone/patternslib/upgrades/1001.zcml
+++ b/src/plone/patternslib/upgrades/1001.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:upgradeStep
+      title="Remove browser layer"
+      description="Remove unneeded browser layer.."
+      source="1000"
+      destination="1001"
+      handler="plone.patternslib.upgrades.upgrade_1000_1001"
+      profile="plone.patternslib:default"
+      />
+
+</configure>

--- a/src/plone/patternslib/upgrades/1003.zcml
+++ b/src/plone/patternslib/upgrades/1003.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:upgradeStep
+      title="Remove registry init in patterns"
+      description=""
+      source="1002"
+      destination="1003"
+      handler="plone.patternslib.upgrades.import_profile"
+      profile="plone.patternslib:default"
+      />
+
+</configure>

--- a/src/plone/patternslib/upgrades/1004.zcml
+++ b/src/plone/patternslib/upgrades/1004.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:upgradeStep
+      title="Remove 2nd markercluster CSS"
+      description=""
+      source="1003"
+      destination="1004"
+      handler="plone.patternslib.upgrades.import_profile"
+      profile="plone.patternslib:default"
+      />
+
+</configure>

--- a/src/plone/patternslib/upgrades/1005.zcml
+++ b/src/plone/patternslib/upgrades/1005.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:upgradeStep
+      title="Update Bundles"
+      description=""
+      source="1004"
+      destination="1005"
+      handler="plone.patternslib.upgrades.import_profile"
+      profile="plone.patternslib:default"
+      />
+
+</configure>

--- a/src/plone/patternslib/upgrades/1006.zcml
+++ b/src/plone/patternslib/upgrades/1006.zcml
@@ -1,0 +1,22 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:registerProfile name="1006"
+    title="Register pat-datetime-picker"
+    description='Configuration for version 1006'
+    directory="profiles/1006"
+    for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+    provides="Products.GenericSetup.interfaces.EXTENSION" />
+
+  <genericsetup:upgradeSteps source="1005"
+    destination="1006"
+    profile="plone.staticresources:default">
+
+    <genericsetup:upgradeDepends
+      title="Register pat-datetime-picker"
+      import_profile="plone.staticresources.upgrades:1006" />
+
+  </genericsetup:upgradeSteps>
+
+</configure>

--- a/src/plone/patternslib/upgrades/__init__.py
+++ b/src/plone/patternslib/upgrades/__init__.py
@@ -2,17 +2,17 @@
 from plone import api
 from plone.browserlayer.utils import unregister_layer
 
-default_profile = 'profile-plone.patternslib:default'
+default_profile = "profile-plone.patternslib:default"
 
 
 def upgrade_1000_1001(context):
     try:
-        unregister_layer(name=u'plone.patternslib')
+        unregister_layer(name=u"plone.patternslib")
     except KeyError:
         # No browser layer with that name registered
         pass
 
 
 def import_profile(context):
-    setup_tool = api.portal.get_tool('portal_setup')
-    setup_tool.runImportStepFromProfile(default_profile, 'plone.app.registry')
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile(default_profile, "plone.app.registry")

--- a/src/plone/patternslib/upgrades/configure.zcml
+++ b/src/plone/patternslib/upgrades/configure.zcml
@@ -3,4 +3,5 @@
   <include file="1003.zcml" />
   <include file="1004.zcml" />
   <include file="1005.zcml" />
+  <include file="1006.zcml" />
 </configure>

--- a/src/plone/patternslib/upgrades/configure.zcml
+++ b/src/plone/patternslib/upgrades/configure.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+  <include file="1001.zcml" />
+  <include file="1003.zcml" />
+  <include file="1004.zcml" />
+  <include file="1005.zcml" />
+</configure>

--- a/src/plone/patternslib/upgrades/profiles/1006/registry.xml
+++ b/src/plone/patternslib/upgrades/profiles/1006/registry.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<registry
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="plone">
+
+  <records
+      prefix="plone.resources/pat-datetime-picker"
+      interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="js">++plone++patternslib/components/patternslib/src/pat/datetime-picker/datetime-picker.js</value>
+    <value key="css">
+      <element>++plone++patternslib/components/patternslib/src/pat/datetime-picker/datetime-picker.css</element>
+    </value>
+  </records>
+
+</registry>


### PR DESCRIPTION
- Register ``pat-datetime-picker`` in the resource registry.
- Restructure upgrades to follow bobtemplates.plone recommendations.