### PR TITLE
Versioning scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 	@echo "🧪 Git add and commit."
 
 	@# Store Patternslib reference
-	@sed -i "s/version=[^,]*/version=\"$(PATTERNSLIB_VERSION).0.dev0\"/" setup.py
+	@sed -i "s/version=[^,]*/version=\"$(PATTERNSLIB_VERSION).dev0\"/" setup.py
 	@git add $(STATIC_DIR) setup.py
 
 	@# Add changelog entry

--- a/README.md
+++ b/README.md
@@ -22,11 +22,19 @@ There are plans to make it available in a separate package.
 
 ## Versioning scheme
 
-The version number of plone.patternslib follows the Patternslib version numbers
-with an added sub-patch level and a possible pre-release suffix.
+The version number of plone.patternslib directly follows the Patternslib version
+numbers.
 
-E.g. if the Patternslib version is 9.9.16 possible plone.patternslib versions
-are `9.9.16.0`, `9.9.16.0a1`, `9.9.16.1` and so on.
+Possible version numbers are:
+
+- 9.9.16
+- 9.10.0-alpha.0
+- 9.10.1-beta.2
+- 9.10.1
+
+Due to strict version parsing of the Python packaging tools we cannot add our
+own patch levels other that `.dev0`, `.dev1` and so on.
+If you want to release a pre-release version, use the dev suffix.
 
 
 ## Implementation

--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ Possible version numbers are:
 - 9.10.1    # Patternslib 9.10.1
 
 
+## Updating Patternslib
+
+Use a branch for updating Patternslib.
+
+To update Patternslib to the latest released version run:
+
+```bash
+make update-patterns
+```
+
+or to update Patternslib to an arbitrary version - e.g. a pre-release:
+
+```bash
+PATTERNSLIB_VERSION=9.10.1-beta.2 make update-patterns
+```
+
+This does the following:
+
+- Download the latest or speficied Patternslib release from GitHub,
+- Copy the Patternslib bundle files to the resource directory in: `src/plone/patternslib/static`,
+- Update the version number in the `setup.py` file,
+- Write a news file,
+- Commit the changes.
+
+You can then make further changes or push your branch and create a pull request.
+Or update the version number for a plone.patternslib specific patch level.
+
+
 ## Implementation
 
 This package includes the Patternslib bundle in a resource directory.

--- a/README.md
+++ b/README.md
@@ -23,18 +23,25 @@ There are plans to make it available in a separate package.
 ## Versioning scheme
 
 The version number of plone.patternslib directly follows the Patternslib version
-numbers.
+numbers and can include a plone.patternlsib specific PATCH level.
+
+This is the scheme:
+
+PA ... Patternslib
+PL ... plone.patternslib
+
+```python
+f"${PA_MAJOR}.${PA_MINOR}.${PA_PATCH}.${PL_PATCH}-${PA_PRE_RELEASE}.${PL_PRE_RELEASE}"
+```
 
 Possible version numbers are:
 
-- 9.9.16
-- 9.10.0-alpha.0
-- 9.10.1-beta.2
-- 9.10.1
-
-Due to strict version parsing of the Python packaging tools we cannot add our
-own patch levels other that `.dev0`, `.dev1` and so on.
-If you want to release a pre-release version, use the dev suffix.
+- 9.9.16      # Patternslib 9.9.16
+- 9.9.16.1    # Patternslib 9.9.16 with a plone.patternslib specific patch
+- 9.10.0-alpha.0 # Patternslib 9.10.0-alpha.0
+- 9.10.1-beta.2 # Patternslib 9.10.1-beta.2
+- 9.10.1.1-beta.2 # Patternslib 9.10.1-beta.2 with a plone.patternslib specific patch
+- 9.10.1    # Patternslib 9.10.1
 
 
 ## Implementation

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ PATTERNSLIB_VERSION=9.10.1-beta.2 make update-patterns
 
 This does the following:
 
-- Download the latest or speficied Patternslib release from GitHub,
-- Copy the Patternslib bundle files to the resource directory in: `src/plone/patternslib/static`,
-- Update the version number in the `setup.py` file,
-- Write a news file,
-- Commit the changes.
+- Downloads the latest or a specified Patternslib release from GitHub.
+- Copies the Patternslib bundle files to the resource directory at `src/plone/patternslib/static`.
+- Updates the version number in the `setup.py` file.
+- Generates a news file.
+- Commits the changes.
 
 You can then make further changes or push your branch and create a pull request.
 Or update the version number for a plone.patternslib specific patch level.


### PR DESCRIPTION
When trying to release a pre-release of  Patternslib `9.10.1-beta.2` as `9.10.1-beta.2.0` I got the error shown below.

In order to keep the versioning scheme in sync with Patternslib itself, we need to give up pre-releases of plone.patternslib.
Unless we do pre-releases with a `.dev0`, `.dev1`, etc suffix, which does work:

```python
Python 3.11.9 (main, Aug  6 2024, 15:48:14) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from packaging.version import Version
>>> Version("9.10.1")
<Version('9.10.1')>
>>> Version("9.10.1-beta.2")
<Version('9.10.1b2')>
>>> Version("9.10.1-beta.2.1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/_thet/data/dev/python-tools/venv/lib/python3.11/site-packages/packaging/version.py", line 202, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
packaging.version.InvalidVersion: Invalid version: '9.10.1-beta.2.1'
>>> Version("9.10.1-beta.2.dev0")
<Version('9.10.1b2.dev0')>
>>> Version("9.10.1-beta.2.dev1")
<Version('9.10.1b2.dev1')>
>>> 

```

What do you think about this?


This is the error:

```bash
thet@thes:/home/_thet/data/dev/syslab/REPOS/quoira/oira-quoira/src/plone.patternslib$ fullrelease 
INFO: Starting prerelease.
Do you want to run check-manifest? (Y/n)? 
['/home/_thet/data/dev/python-tools/venv/bin/python', 'setup.py', 'sdist', '-d', '/home/thet/tmp/check-manifest-g46bcfvh-sdist'] failed (status 1):
/home/_thet/data/dev/python-tools/venv/lib/python3.11/site-packages/setuptools/dist.py:701: SetuptoolsDeprecationWarning: The namespace_packages parameter is deprecated.
!!

        ********************************************************************************
        Please replace its usage with implicit namespaces (PEP 420).

        See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages for details.
        ********************************************************************************

!!
  ep.load()(self, ep.name, value)
Traceback (most recent call last):
  File "/home/_thet/data/dev/syslab/REPOS/quoira/oira-quoira/src/plone.patternslib/setup.py", line 15, in <module>
    setup(
  File "/home/_thet/data/dev/python-tools/venv/lib/python3.11/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/_thet/data/dev/python-tools/venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 148, in setup
    _setup_distribution = dist = klass(attrs)
                                 ^^^^^^^^^^^^
  File "/home/_thet/data/dev/python-tools/venv/lib/python3.11/site-packages/setuptools/dist.py", line 330, in __init__
    self.metadata.version = self._normalize_version(self.metadata.version)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/_thet/data/dev/python-tools/venv/lib/python3.11/site-packages/setuptools/dist.py", line 366, in _normalize_version
    normalized = str(Version(version))
                     ^^^^^^^^^^^^^^^^
  File "/home/_thet/data/dev/python-tools/venv/lib/python3.11/site-packages/packaging/version.py", line 202, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
packaging.version.InvalidVersion: Invalid version: '9.10.1-beta.2.0.dev0'

Something bad happened. Do you want to continue despite that? (y/N)? N
```
