### PR TITLE
Order Patternslib bundle at the end.

### DIFF
--- a/news/+order-patternslib-end.internal.md
+++ b/news/+order-patternslib-end.internal.md
@@ -1,0 +1,9 @@
+Order Patternslib bundle at the end.
+
+In case the main `plone` bundle is not available, depending on `plone` would
+break the resource registry. This moves rendering of the `patterns` bundle to
+the end of all resource registry bundles and avoids depending on `plone`.
+
+Note: In this case you'd need to change the `patterns` bundle to use
+`bundle.min.js` - the main module federation bundle instead of `remote.min.js`
+or use another main module federation bundle.

--- a/src/plone/patternslib/profiles/default/metadata.xml
+++ b/src/plone/patternslib/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>2000</version>
+  <version>2001</version>
 </metadata>

--- a/src/plone/patternslib/profiles/default/registry.xml
+++ b/src/plone/patternslib/profiles/default/registry.xml
@@ -9,6 +9,6 @@
     <value key="load_async">False</value>
     <value key="load_defer">False</value>
     <value key="expression" />
-    <value key="depends">plone</value>
+    <value key="depends">all</value>
   </records>
 </registry>

--- a/src/plone/patternslib/upgrades/2001.zcml
+++ b/src/plone/patternslib/upgrades/2001.zcml
@@ -1,0 +1,28 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    >
+
+  <genericsetup:registerProfile
+      name="2001"
+      title="Order Patternslib bundle at the end"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      directory="profiles/2001"
+      />
+
+  <genericsetup:upgradeSteps
+      profile="plone.patternslib:default"
+      source="2000"
+      destination="2001"
+      >
+
+    <genericsetup:upgradeDepends
+        title="Order Patternslib bundle at the end"
+        import_profile="plone.patternslib.upgrades:2001"
+        />
+
+  </genericsetup:upgradeSteps>
+
+</configure>

--- a/src/plone/patternslib/upgrades/configure.zcml
+++ b/src/plone/patternslib/upgrades/configure.zcml
@@ -7,4 +7,5 @@
   <include file="1007.zcml" />
   <include file="1008.zcml" />
   <include file="2000.zcml" />
+  <include file="2001.zcml" />
 </configure>

--- a/src/plone/patternslib/upgrades/profiles/2001/registry.xml
+++ b/src/plone/patternslib/upgrades/profiles/2001/registry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry>
+
+  <records interface="plone.base.interfaces.IBundleRegistry"
+           prefix="plone.bundles/patterns"
+  >
+    <value key="depends">all</value>
+  </records>
+
+</registry>


### PR DESCRIPTION
In case the main `plone` bundle is not available, depending on `plone` would break the resource registry. This moves rendering of the `patterns` bundle to the end of all resource registry bundles and avoids depending on `plone`.

Note: In this case you'd need to change the `patterns` bundle to use `bundle.min.js` - the main module federation bundle instead of `remote.min.js` or use another main module federation bundle.