### PR TITLE
Blacklist unwanted Patterns.

### DIFF
--- a/news/patternslib-preinit.bugfix
+++ b/news/patternslib-preinit.bugfix
@@ -1,0 +1,6 @@
+Blacklist unwanted Patterns.
+
+Add a patternslib-preinit.js resource as bundle in the resource registry.
+Currently this script blacklists any unwanted Patternslib Patterns. Most
+prominent this is "pat-legend" which would transform any "legend" tags to
+"p" tags and break form-tabbing with pat-autotoc.

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     ],
     extras_require={
         "test": [
+            "plone.api",
             "plone.app.testing",
             "plone.base",
         ],

--- a/src/plone/patternslib/configure.zcml
+++ b/src/plone/patternslib/configure.zcml
@@ -7,6 +7,10 @@
   <include package=".browser" />
   <include package=".upgrades" />
 
+  <browser:resource
+      name="patternslib-preinit.js"
+      file="patternslib-preinit.js"
+      />
   <browser:resourceDirectory
       name="patternslib"
       directory="static"

--- a/src/plone/patternslib/patternslib-preinit.js
+++ b/src/plone/patternslib/patternslib-preinit.js
@@ -1,0 +1,12 @@
+/*
+ * Patternslib pre-initialization.
+ * This removes some patterns from being auto-initialized:
+ * */
+
+window.__patternslib_patterns_blacklist = [
+    "legend", // Transforms <legend> to <p>, breaks pat-autotoc form tabbing.
+    // Duplicates
+    //"modal",
+    //"sortable",
+    //"toggle",
+];

--- a/src/plone/patternslib/profiles/default/metadata.xml
+++ b/src/plone/patternslib/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>2000</version>
+  <version>2001</version>
 </metadata>

--- a/src/plone/patternslib/profiles/uninstall/registry.xml
+++ b/src/plone/patternslib/profiles/uninstall/registry.xml
@@ -6,4 +6,8 @@
            prefix="plone.bundles/patterns"
            remove="True"
   />
+  <records interface="plone.base.interfaces.IBundleRegistry"
+           prefix="plone.bundles/patterns-preinit"
+           remove="True"
+  />
 </registry>

--- a/src/plone/patternslib/tests/test_setup.py
+++ b/src/plone/patternslib/tests/test_setup.py
@@ -1,7 +1,9 @@
+from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.base.utils import get_installer
 from plone.patternslib.testing import PLONE_PATTERNSLIB_INTEGRATION_TESTING
+from Products.CMFPlone.resources.browser.resource import ScriptsView
 
 import unittest
 
@@ -17,6 +19,50 @@ class TestSetup(unittest.TestCase):
     def test_product_installed(self):
         self.assertTrue(self.installer.is_product_installed("plone.patternslib"))
 
+    def test_resources_installed(self):
+        rec = api.portal.get_registry_record
+
+        # patterns
+        self.assertEqual(
+            rec("plone.bundles/patterns.jscompilation"),
+            "++resource++patternslib/remote.min.js",
+        )
+        self.assertEqual(
+            rec("plone.bundles/patterns.enabled"),
+            True,
+        )
+        self.assertEqual(
+            rec("plone.bundles/patterns.depends"),
+            "patterns-preinit",
+        )
+
+        # patterns-preinit
+        self.assertEqual(
+            rec("plone.bundles/patterns-preinit.jscompilation"),
+            "++resource++patternslib-preinit.js",
+        )
+        self.assertEqual(
+            rec("plone.bundles/patterns-preinit.enabled"),
+            True,
+        )
+        self.assertEqual(
+            rec("plone.bundles/patterns-preinit.depends"),
+            "plone",
+        )
+
+    def test_resources_rendered(self):
+        view = ScriptsView(self.portal, self.portal.REQUEST, None, None)
+        view.update()
+        results = view.render()
+        self.assertIn(
+            "++resource++patternslib/remote.min.js",
+            results,
+        )
+        self.assertIn(
+            "++resource++patternslib-preinit.js",
+            results,
+        )
+
 
 class TestUninstall(unittest.TestCase):
 
@@ -30,3 +76,30 @@ class TestUninstall(unittest.TestCase):
 
     def test_product_uninstalled(self):
         self.assertFalse(self.installer.is_product_installed("plone.patternslib"))
+
+    def test_resources_uninstalled(self):
+        rec = api.portal.get_registry_record
+
+        # patterns
+        self.assertEqual(
+            rec("plone.bundles/patterns.jscompilation", default=None),
+            None,
+        )
+        # patterns-preinit
+        self.assertEqual(
+            rec("plone.bundles/patterns-preinit.jscompilation", default=None),
+            None,
+        )
+
+    def test_resources_not_rendered(self):
+        view = ScriptsView(self.portal, self.portal.REQUEST, None, None)
+        view.update()
+        results = view.render()
+        self.assertNotIn(
+            "++resource++patternslib/remote.min.js",
+            results,
+        )
+        self.assertNotIn(
+            "++resource++patternslib-preinit.js",
+            results,
+        )

--- a/src/plone/patternslib/upgrades/2001.zcml
+++ b/src/plone/patternslib/upgrades/2001.zcml
@@ -1,0 +1,28 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    >
+
+  <genericsetup:registerProfile
+      name="2001"
+      title="Add patternslib-preinit.js resource"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      directory="profiles/2001"
+      />
+
+  <genericsetup:upgradeSteps
+      profile="plone.patternslib:default"
+      source="*"
+      destination="2001"
+      >
+
+    <genericsetup:upgradeDepends
+        title="Add patternslib-preinit.js resource"
+        import_profile="plone.patternslib.upgrades:2001"
+        />
+
+  </genericsetup:upgradeSteps>
+
+</configure>

--- a/src/plone/patternslib/upgrades/configure.zcml
+++ b/src/plone/patternslib/upgrades/configure.zcml
@@ -7,4 +7,5 @@
   <include file="1007.zcml" />
   <include file="1008.zcml" />
   <include file="2000.zcml" />
+  <include file="2001.zcml" />
 </configure>

--- a/src/plone/patternslib/upgrades/profiles/2001/registry.xml
+++ b/src/plone/patternslib/upgrades/profiles/2001/registry.xml
@@ -15,12 +15,6 @@
   <records interface="plone.base.interfaces.IBundleRegistry"
            prefix="plone.bundles/patterns"
   >
-    <value key="enabled">True</value>
-    <value key="jscompilation">++resource++patternslib/remote.min.js</value>
-    <value key="csscompilation" />
-    <value key="load_async">False</value>
-    <value key="load_defer">False</value>
-    <value key="expression" />
     <value key="depends">patterns-preinit</value>
   </records>
 </registry>


### PR DESCRIPTION
Add a patternslib-preinit.js resource as bundle in the resource registry. Currently this script blacklists any unwanted Patternslib Patterns. Most prominent this is "pat-legend" which would transform any `<legend>` tags to `<p>` tags and break form-tabbing with pat-autotoc.

Ref: https://github.com/Patternslib/Patterns/issues/1259

